### PR TITLE
updated with `v4-hooks-public`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/v4-hooks-public"]
+	path = lib/v4-hooks-public
+	url = https://github.com/Uniswap/v4-hooks-public

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/forge-std": {
+    "rev": "77041d2ce690e692d6e03cc812b57d1ddaa4d505"
+  },
+  "lib/v4-periphery": {
+    "rev": "eeb3eff28dd5f5f17aa94180fa3610ff59b0e1c8"
+  }
+}

--- a/src/PointsHook.sol
+++ b/src/PointsHook.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import {BaseHook} from "v4-periphery/src/utils/BaseHook.sol";
+import {BaseHook} from "lib/v4-hooks-public/src/base/BaseHook.sol";
 import {ERC1155} from "solmate/src/tokens/ERC1155.sol";
 
 import {Currency} from "v4-core/types/Currency.sol";


### PR DESCRIPTION
In the recent update, Uniswap removed `hooks` from `v4-periphery` to `v4-hooks-public`. That's why people are having trouble following your tutorial. I have fixed that problem by installing and importing `v4-hooks-public` in the repository.